### PR TITLE
Updates go CI workflow

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -11,7 +11,12 @@ on:
     branches:
       - main
     paths:
-      - /**/*.go
+      - cmd
+      - internal
+      - pkg
+      - .github/workflows/go.yaml
+      - go.mod
+      - "!**.md"
 
 jobs:
 

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.22', '1.23', '1.24']
+        go-version: ['1.23.x', '1.24.x', '1.25.x']
     steps:
     - uses: actions/checkout@v4
 
@@ -50,4 +50,4 @@ jobs:
 
     - name: Benchmark
       if: github.event_name != 'pull_request'
-      run: go test -v -run=^$ -bench=. -benchmem ./...
+      run: go test -v -run=^$ -bench=. -benchmem -timeout=20m ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,9 +5,13 @@ name: Go
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - main
+    paths:
+      - /**/*.go
 
 jobs:
 


### PR DESCRIPTION
This PR:
- Causes the workflow on PRs only when a non-markdown is changed under source dirs, or if go.mod changes
- Renames the workflow
- Lengthens the amount of time for benchmark
- Updates go versions